### PR TITLE
Use items() to iterate when using a preexisting dictionary

### DIFF
--- a/dict2dot/__init__.py
+++ b/dict2dot/__init__.py
@@ -32,8 +32,8 @@ class Dict2Dot(dict):
     '''
     def __init__(self, orig={}):
         # Set a preexistent dict into self
-        for key in orig:
-            self.__setattr__(key, orig[key])
+        for key, value in orig.items():
+            self.__setattr__(key, value)
 
     def __getattr__(self, key):
         # Return a value from the dict (even nested)


### PR DESCRIPTION
Tests with timeit show (at least on my environment) that iterating with items takes only 75% of the time it takes without it. Might help with very big dictionaries
(also looks more pythonic to me)